### PR TITLE
Add ability to view details of todo item and update todo items

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -10,5 +10,6 @@ module.exports = {
   plugins: ['react-refresh'],
   rules: {
     'react-refresh/only-export-components': 'warn',
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,14 @@ function App() {
     setTodoItems([...todoItems, response.data]);
   };
 
+  const handleUpdateTodo = async (payload: TodoPayload) => {
+    const response = await todoService.updateTodo(payload.id!, payload);
+    const updatedTodoItems = todoItems.map((todoItem) =>
+      todoItem.id === payload.id ? response.data : todoItem
+    );
+    setTodoItems(updatedTodoItems);
+  };
+
   return (
     <>
       <Header />
@@ -50,6 +58,7 @@ function App() {
         todoFilter={todoFilter}
         handleTodoIsCompleteChange={handleTodoIsCompleteChange}
         handleDeleteTodo={handleDeleteTodo}
+        handleUpdateTodo={handleUpdateTodo}
       />
     </>
   );

--- a/frontend/src/components/CreateTodo.tsx
+++ b/frontend/src/components/CreateTodo.tsx
@@ -1,5 +1,6 @@
 import styles from '@/components/CreateTodo.module.scss';
-import TodoModal, { MODAL_MODE } from '@/components/TodoModal';
+import TodoModal from '@/components/TodoModal';
+import { MODAL_MODE } from '@/utils/constants';
 import { TodoPayload } from '@/utils/interfaces';
 import { useState } from 'react';
 import Button from 'react-bootstrap/Button';

--- a/frontend/src/components/CreateTodo.tsx
+++ b/frontend/src/components/CreateTodo.tsx
@@ -1,5 +1,5 @@
 import styles from '@/components/CreateTodo.module.scss';
-import CreateTodoModal from '@/components/CreateTodoModal';
+import TodoModal, { MODAL_MODE } from '@/components/TodoModal';
 import { TodoPayload } from '@/utils/interfaces';
 import { useState } from 'react';
 import Button from 'react-bootstrap/Button';
@@ -20,9 +20,10 @@ function CreateTodo({ handleSubmit }: CreateTodoProps) {
       >
         Create Todo
       </Button>
-      <CreateTodoModal
+      <TodoModal
         handleSubmit={handleSubmit}
         show={showCreateTodoModal}
+        mode={MODAL_MODE.CREATE}
         onHide={() => setShowCreateTodoModal(false)}
       />
     </Stack>

--- a/frontend/src/components/TodoItems.module.scss
+++ b/frontend/src/components/TodoItems.module.scss
@@ -1,7 +1,3 @@
-p {
-  margin: 0;
-}
-
 .items {
   margin-top: 16px;
 
@@ -12,5 +8,9 @@ p {
   .checkboxColumn {
     display: flex;
     justify-content: end;
+  }
+
+  .todoTitle {
+    margin: 0;
   }
 }

--- a/frontend/src/components/TodoItems.tsx
+++ b/frontend/src/components/TodoItems.tsx
@@ -1,7 +1,9 @@
 import { ReactComponent as TrashIcon } from '@/assets/trash.svg';
 import styles from '@/components/TodoItems.module.scss';
-import { TODO_TAB_FILTER } from '@/utils/constants';
-import { ITodoItem } from '@/utils/interfaces';
+import TodoModal from '@/components/TodoModal';
+import { MODAL_MODE, TODO_TAB_FILTER } from '@/utils/constants';
+import { ITodoItem, TodoPayload } from '@/utils/interfaces';
+import { useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
@@ -12,6 +14,7 @@ import Stack from 'react-bootstrap/Stack';
 interface Base {
   handleTodoIsCompleteChange: (id: string) => void;
   handleDeleteTodo: (id: string) => void;
+  handleUpdateTodo: (payload: TodoPayload) => void;
 }
 interface TodoItemsProps extends Base {
   todoItems: ITodoItem[];
@@ -22,7 +25,13 @@ interface TodoItemProps extends Base {
   todoItem: ITodoItem;
 }
 
-function TodoItem({ todoItem, handleTodoIsCompleteChange, handleDeleteTodo }: TodoItemProps) {
+function TodoItem({
+  todoItem,
+  handleTodoIsCompleteChange,
+  handleDeleteTodo,
+  handleUpdateTodo,
+}: TodoItemProps) {
+  const [showTodoModal, setShowTodoModal] = useState<boolean>(false);
   return (
     <Row
       className={`${todoItem.isCompleted ? styles.completedItem : ''} mb-2`}
@@ -33,6 +42,17 @@ function TodoItem({ todoItem, handleTodoIsCompleteChange, handleDeleteTodo }: To
         <Form.Check
           checked={todoItem.isCompleted}
           onChange={() => handleTodoIsCompleteChange(todoItem.id)}
+        />
+      </Col>
+      <Col>
+        <Button variant="primary" onClick={() => setShowTodoModal(true)}>
+          View details
+        </Button>
+        <TodoModal
+          handleSubmit={handleUpdateTodo}
+          show={showTodoModal}
+          mode={MODAL_MODE.EDIT}
+          onHide={() => setShowTodoModal(false)}
         />
       </Col>
       <Col>
@@ -61,6 +81,7 @@ function TodoItems({
   handleTodoIsCompleteChange,
   handleDeleteTodo,
   todoFilter,
+  handleUpdateTodo,
 }: TodoItemsProps) {
   return (
     <Container className={styles.items}>
@@ -82,6 +103,7 @@ function TodoItems({
               todoItem={todoItem}
               handleTodoIsCompleteChange={handleTodoIsCompleteChange}
               handleDeleteTodo={handleDeleteTodo}
+              handleUpdateTodo={handleUpdateTodo}
             />
           );
         })}

--- a/frontend/src/components/TodoItems.tsx
+++ b/frontend/src/components/TodoItems.tsx
@@ -34,7 +34,7 @@ function TodoItem({
   const [showTodoModal, setShowTodoModal] = useState<boolean>(false);
   return (
     <Row
-      className={`${todoItem.isCompleted ? styles.completedItem : ''} mb-2`}
+      className={`${todoItem.isCompleted ? styles.completedItem : ''} mb-4 align-items-center`}
       gap={2}
       direction="horizontal"
     >
@@ -45,7 +45,7 @@ function TodoItem({
         />
       </Col>
       <Col>
-        <Button variant="primary" onClick={() => setShowTodoModal(true)}>
+        <Button variant="outline-primary" onClick={() => setShowTodoModal(true)}>
           View details
         </Button>
         <TodoModal
@@ -53,10 +53,11 @@ function TodoItem({
           show={showTodoModal}
           mode={MODAL_MODE.EDIT}
           onHide={() => setShowTodoModal(false)}
+          existingTodo={todoItem}
         />
       </Col>
       <Col>
-        <p>{todoItem.title}</p>
+        <p className={styles.todoTitle}>{todoItem.title}</p>
       </Col>
       <Col>
         <Button

--- a/frontend/src/components/TodoModal.tsx
+++ b/frontend/src/components/TodoModal.tsx
@@ -15,6 +15,7 @@ interface TodoModalProps {
   mode: (typeof MODAL_MODE)[keyof typeof MODAL_MODE];
   onHide: () => void;
   handleSubmit: (payload: TodoPayload) => void;
+  existingTodo?: TodoPayload;
 }
 
 interface TodoFormData {
@@ -23,7 +24,7 @@ interface TodoFormData {
   priorityInput: { value: 'high' | 'medium' | 'low' };
 }
 
-function TodoModal({ show, mode, onHide, handleSubmit, ...rest }: TodoModalProps) {
+function TodoModal({ show, mode, onHide, handleSubmit, existingTodo, ...rest }: TodoModalProps) {
   const [validated, setValidated] = useState<boolean>(false);
   const handleHideModal = () => {
     onHide();
@@ -47,6 +48,7 @@ function TodoModal({ show, mode, onHide, handleSubmit, ...rest }: TodoModalProps
               title: titleInput.value,
               description: descriptionInput.value,
               priority: priorityInput.value,
+              id: existingTodo?.id,
             });
             handleHideModal();
           }
@@ -62,6 +64,7 @@ function TodoModal({ show, mode, onHide, handleSubmit, ...rest }: TodoModalProps
               name="titleInput"
               type="text"
               placeholder="Review CS 240 Lecture on priority queue"
+              defaultValue={existingTodo?.title}
               required
             />
             <Form.Control.Feedback type="invalid">Please provide a title.</Form.Control.Feedback>
@@ -71,6 +74,7 @@ function TodoModal({ show, mode, onHide, handleSubmit, ...rest }: TodoModalProps
             <Form.Control
               as="textarea"
               name="descriptionInput"
+              defaultValue={existingTodo?.description}
               placeholder="Go over the lecture slides, tutorials, and assignments. Do LeetCode practice problems with priority queue."
             />
           </Form.Group>
@@ -82,6 +86,7 @@ function TodoModal({ show, mode, onHide, handleSubmit, ...rest }: TodoModalProps
               id="todo.priorityHighInput"
               type="radio"
               label="High"
+              defaultChecked={existingTodo?.priority === 'high'}
             />
             <Form.Check
               name="priorityInput"
@@ -89,7 +94,7 @@ function TodoModal({ show, mode, onHide, handleSubmit, ...rest }: TodoModalProps
               id="todo.priorityMediumInput"
               type="radio"
               label="Medium"
-              defaultChecked
+              defaultChecked={existingTodo ? existingTodo.priority === 'medium' : true}
             />
             <Form.Check
               name="priorityInput"
@@ -97,6 +102,7 @@ function TodoModal({ show, mode, onHide, handleSubmit, ...rest }: TodoModalProps
               id="todo.priorityLowInput"
               type="radio"
               label="Low"
+              defaultChecked={existingTodo?.priority === 'low'}
             />
           </Form.Group>
         </Modal.Body>

--- a/frontend/src/components/TodoModal.tsx
+++ b/frontend/src/components/TodoModal.tsx
@@ -4,8 +4,19 @@ import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import Modal from 'react-bootstrap/Modal';
 
-interface CreateTodoModalProps {
+export const MODAL_MODE = Object.freeze({
+  EDIT: 'edit',
+  CREATE: 'create',
+});
+
+const MODAL_TITLE = Object.freeze({
+  [MODAL_MODE.CREATE]: 'Create Todo',
+  [MODAL_MODE.EDIT]: 'Update Todo',
+});
+
+interface TodoModalProps {
   show: boolean;
+  mode: (typeof MODAL_MODE)[keyof typeof MODAL_MODE];
   onHide: () => void;
   handleSubmit: (payload: TodoPayload) => void;
 }
@@ -16,7 +27,7 @@ interface TodoFormData {
   priorityInput: { value: 'high' | 'medium' | 'low' };
 }
 
-function CreateTodoModal({ show, onHide, handleSubmit, ...rest }: CreateTodoModalProps) {
+function TodoModal({ show, mode, onHide, handleSubmit, ...rest }: TodoModalProps) {
   const [validated, setValidated] = useState<boolean>(false);
   const handleHideModal = () => {
     onHide();
@@ -45,6 +56,9 @@ function CreateTodoModal({ show, onHide, handleSubmit, ...rest }: CreateTodoModa
           }
         }}
       >
+        <Modal.Header>
+          <Modal.Title>{MODAL_TITLE[mode]}</Modal.Title>
+        </Modal.Header>
         <Modal.Body>
           <Form.Group className="mb-3" controlId="todo.titleInput">
             <Form.Label>Title</Form.Label>
@@ -103,4 +117,4 @@ function CreateTodoModal({ show, onHide, handleSubmit, ...rest }: CreateTodoModa
   );
 }
 
-export default CreateTodoModal;
+export default TodoModal;

--- a/frontend/src/components/TodoModal.tsx
+++ b/frontend/src/components/TodoModal.tsx
@@ -1,13 +1,9 @@
+import { MODAL_MODE } from '@/utils/constants';
 import { TodoPayload } from '@/utils/interfaces';
 import { useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import Modal from 'react-bootstrap/Modal';
-
-export const MODAL_MODE = Object.freeze({
-  EDIT: 'edit',
-  CREATE: 'create',
-});
 
 const MODAL_TITLE = Object.freeze({
   [MODAL_MODE.CREATE]: 'Create Todo',

--- a/frontend/src/services/todoService.ts
+++ b/frontend/src/services/todoService.ts
@@ -15,6 +15,7 @@ const todoService = (() => {
   };
 
   const createTodo = async (payload: TodoPayload) => {
+    delete payload.id;
     const createdTodo = await axios.post<ITodoItem>(todosApiRoute, payload);
     return createdTodo;
   };

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -3,3 +3,8 @@ export const TODO_TAB_FILTER = Object.freeze({
   SHOW_INCOMPLETE: { eventKey: 'showIncomplete', label: 'Incomplete' },
   SHOW_COMPLETED: { eventKey: 'showCompleted', label: 'Completed' },
 });
+
+export const MODAL_MODE = Object.freeze({
+  EDIT: 'edit',
+  CREATE: 'create',
+});

--- a/frontend/src/utils/interfaces.ts
+++ b/frontend/src/utils/interfaces.ts
@@ -7,6 +7,7 @@ export interface ITodoItem {
 }
 
 export interface TodoPayload {
+  id?: string;
   title?: string;
   description?: string;
   isCompleted?: boolean;


### PR DESCRIPTION
## What does this PR do?

- Add a button for opening a modal that displays details of a todo item: `title`, `description`, and `priority`.
- The modal supports the update of the existing todo

## How should this be tested?

- Create some todo items to start
- Click on "View details" of a todo items
- Ensure correct details showed up for the existing todo
- Update any field and click Save
- Ensure the todo was updated correctly by clicking on View details
